### PR TITLE
Add parse context tracking for better error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /spec/.testml
 /test.yml
 /tmp
+/.bundle
+/.gems

--- a/test/parse_context_test.rb
+++ b/test/parse_context_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestParseContext < Minitest::Test
+  def test_unclosed_flow_sequence_shows_context
+    yaml = "servers: [a, b"
+    
+    error = assert_raises(Psych::SyntaxError) do
+      Psych::Pure.load(yaml)
+    end
+    
+    assert_includes error.message, "within:"
+    assert_includes error.message, "flow sequence"
+  end
+  
+  def test_unclosed_double_quoted_shows_context
+    yaml = %q{config: "unclosed string}
+    
+    error = assert_raises(Psych::SyntaxError) do
+      Psych::Pure.load(yaml)
+    end
+    
+    assert_includes error.message, "within:"
+    assert_includes error.message, "double quoted scalar"
+  end
+  
+  def test_nested_structure_shows_full_context
+    yaml = <<~YAML
+      config:
+        nested:
+          value: \"unclosed
+    YAML
+    
+    error = assert_raises(Psych::SyntaxError) do
+      Psych::Pure.load(yaml)
+    end
+    
+    assert_includes error.message, "within:"
+    assert_includes error.message, "block mapping"
+    assert_includes error.message, "double quoted scalar"
+  end
+end


### PR DESCRIPTION
Track the parsing context (flow sequences, flow mappings, block sequences, block mappings, double-quoted scalars) to provide more helpful error messages when parsing fails.

The parser now maintains a stack of parsing contexts and includes this information in syntax errors. For example, an unclosed flow sequence now shows "Parse context: flow_sequence" instead of just "Parser finished before end of input".

This is especially helpful after backtracking, where the parser may have tried multiple paths before failing. The implementation tracks the deepest parse stack reached to provide context even after backtracking empties the current stack.