### PR TITLE
FIX: merge losing comments from second hash

### DIFF
--- a/lib/psych/pure.rb
+++ b/lib/psych/pure.rb
@@ -192,6 +192,17 @@ module Psych
         @trailing << comment
       end
 
+      def initialize_dup(other)
+        super
+        @leading = other.leading.dup
+        @trailing = other.trailing.dup
+      end
+
+      def merge(other)
+        @leading.concat(other.leading)
+        @trailing.concat(other.trailing)
+      end
+
       # Execute the given block without the leading comments being visible. This
       # is used when a node has already handled its child nodes' leading
       # comments, so they should not be processed again.
@@ -299,11 +310,13 @@ module Psych
 
       def initialize_clone(obj, freeze: nil)
         super
+        @psych_node = obj.psych_node.dup
         @psych_keys = obj.psych_keys.map(&:dup)
       end
 
       def initialize_dup(obj)
         super
+        @psych_node = obj.psych_node.dup
         @psych_keys = obj.psych_keys.map(&:dup)
       end
 
@@ -412,10 +425,8 @@ module Psych
             end
 
             # Merge comments from the other hash's psych_node
-            if other.psych_node&.comments? && (other_leading = other.psych_node.comments.leading).any?
-              if @psych_node&.comments?
-                @psych_node.comments.leading.concat(other_leading)
-              end
+            if other.psych_node&.comments?
+              @psych_node.comments.merge(other.psych_node.comments)
             end
           else
             # Regular hash - just wrap keys and values
@@ -670,6 +681,11 @@ module Psych
 
         def comments
           @comments ||= Comments.new
+        end
+
+        def initialize_dup(other)
+          super
+          @comments = other.comments.dup if other.comments?
         end
 
         def comments?

--- a/test/loaded_hash_test.rb
+++ b/test/loaded_hash_test.rb
@@ -383,6 +383,48 @@ module Psych
         assert_includes output, "a: 1"
         assert_includes output, "b: 2"
       end
+
+      def test_merge_does_not_mutate_original_comments
+        yaml1 = <<~YAML
+          # first
+          a: 1
+        YAML
+
+        yaml2 = <<~YAML
+          # second
+          b: 2
+        YAML
+
+        content1 = Psych::Pure.load(yaml1, comments: true)
+        content2 = Psych::Pure.load(yaml2, comments: true)
+        content1.merge(content2)
+
+        output = Psych::Pure.dump(content1)
+
+        assert_includes output, "# first"
+        refute_includes output, "# second"
+      end
+
+      def test_merge_bang_preserves_comments_into_commentless_hash
+        yaml1 = <<~YAML
+          a: 1
+        YAML
+
+        yaml2 = <<~YAML
+          # comment
+          b: 2
+        YAML
+
+        content1 = Psych::Pure.load(yaml1, comments: true)
+        content2 = Psych::Pure.load(yaml2, comments: true)
+        content1.merge!(content2)
+
+        output = Psych::Pure.dump(content1)
+
+        assert_includes output, "# comment"
+        assert_includes output, "a: 1"
+        assert_includes output, "b: 2"
+      end
     end
   end
 end


### PR DESCRIPTION
When merging two LoadedHash objects, comments from the second hash were being lost. This happened because merge! was iterating over the other hash as a regular hash, which lost the psych_keys metadata.

Additionally, comments are stored on the hash's psych_node, not on individual key/value nodes, so those needed to be merged as well.

Changes:
- Updated LoadedHash#merge! to check if other is a LoadedHash
- When merging a LoadedHash, copy its psych_keys to preserve metadata
- Merge leading comments from other.psych_node into result
- Added test case that reproduces the issue

fixes #51 