### PR TITLE
Fix source line offsets for multibyte input

### DIFF
--- a/lib/psych/pure.rb
+++ b/lib/psych/pure.rb
@@ -51,7 +51,7 @@ module Psych
         @last_line_offset = 0
 
         idx = 0
-        while (found = string.index("\n", idx))
+        while (found = string.byteindex("\n", idx))
           offsets << (idx = found + 1)
         end
 

--- a/test/dump_test.rb
+++ b/test/dump_test.rb
@@ -295,6 +295,30 @@ module Psych
           assert_equal(expected, dump(expected))
         end
 
+        def test_multibyte_does_not_add_blank_lines
+          source = <<~YAML
+            ---
+            ja:
+              dashboard: ダッシュボード
+              welcome: ようこそ
+          YAML
+
+          assert_equal source, dump(source)
+        end
+
+        def test_multibyte_preserves_blank_lines
+          source = <<~YAML
+            ---
+            挨拶: こんにちは
+
+            案内: いらっしゃいませ
+
+            結び: また会いましょう
+          YAML
+
+          assert_equal source, dump(source)
+        end
+
         private
 
         def dump(source, options = {})

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -42,6 +42,17 @@ module Psych
         assert_kind_of Nodes::Scalar, parse("1")
       end
 
+      def test_multibyte_start_lines
+        source = <<~YAML
+          名前: 山田太郎
+          挨拶: こんにちは
+          住所: 東京都
+        YAML
+        nodes = parse(source).children
+
+        assert_equal [0, 0, 1, 1, 2, 2], nodes.map(&:start_line)
+      end
+
       def test_sequence_block
         assert_kind_of Nodes::Sequence, parse("- 1")
       end


### PR DESCRIPTION
`Source` builds its line offset table with `String#index` (character offsets),
while the parser (`StringScanner#pos`) and trimming logic use byte offsets.
This mismatch causes incorrect line calculation for multibyte input and leads
to unexpected blank lines being added or removed during round trips.

Switch to `String#byteindex` so the table consistently stores byte offsets.
`String#byteindex` is available since Ruby 3.2, and this repository's CI
currently targets Ruby 3.3 and newer.

Regression tests cover:

- Scalar start lines after multibyte content
- Preventing unintended blank lines during round trips
- Preserving existing blank lines during round trips

Column offsets remain byte-based; this change only fixes the inconsistent line
lookup.

Tested with `bundle exec rake test`:

- Ruby 3.3.5: 171 runs, 470 assertions
- Ruby 4.0.1: 171 runs, 470 assertions

Both runs completed with 0 failures and 0 errors.